### PR TITLE
fix(security): pin slack action SHA + anchor Gmail/Drive detection regexes

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -160,7 +160,7 @@ jobs:
 
       # ── 2. Post to Slack via chat.postMessage ──
       - name: Send to Slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           channel-id: C0ALY3XA6GZ                          # Sapience AI internal channel
           payload: ${{ steps.payload.outputs.json }}

--- a/src/middlewares/hitl/tool-interceptor.ts
+++ b/src/middlewares/hitl/tool-interceptor.ts
@@ -299,10 +299,10 @@ function detectApiSignatureInContent(
     return { module: 'GoogleDrive', method: detectDriveApiMethod(lower) };
   }
   // Direct Gmail/Drive REST API calls (not via Maton gateway)
-  if (/gmail\.googleapis\.com|www\.googleapis\.com\/gmail/i.test(content)) {
+  if (/\bgmail\.googleapis\.com|\bwww\.googleapis\.com\/gmail/i.test(content)) {
     return { module: 'Gmail', method: detectGmailApiMethod(lower) };
   }
-  if (/www\.googleapis\.com\/drive|drive\.googleapis\.com/i.test(content)) {
+  if (/\bwww\.googleapis\.com\/drive|\bdrive\.googleapis\.com/i.test(content)) {
     return { module: 'GoogleDrive', method: detectDriveApiMethod(lower) };
   }
   return undefined;

--- a/src/middlewares/hitl/tool-interceptor.ts
+++ b/src/middlewares/hitl/tool-interceptor.ts
@@ -279,6 +279,36 @@ function detectGmailApiMethod(url: string): string {
 }
 
 /**
+ * Returns true iff `needle` occurs in `haystack` with a non-host-character
+ * (or start-of-string) immediately preceding it. Used to reject look-alike
+ * hosts like `notgmail.googleapis.com` while still matching legitimate URLs
+ * embedded anywhere in arbitrary content.
+ *
+ * No regex: avoids CodeQL js/regex/missing-regexp-anchor (the rule wants
+ * ^/$ anchors, but anchoring is impossible when scanning arbitrary content
+ * that embeds a URL).
+ */
+function containsHostBoundary(haystack: string, needle: string): boolean {
+  let from = 0;
+  while (from <= haystack.length) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) return false;
+    if (idx === 0) return true;
+    const prev = haystack.charCodeAt(idx - 1);
+    // Host chars: a-z, A-Z, 0-9, '-', '.'. Anything else is a boundary.
+    const isHostChar =
+      (prev >= 0x61 && prev <= 0x7a) || // a-z
+      (prev >= 0x41 && prev <= 0x5a) || // A-Z
+      (prev >= 0x30 && prev <= 0x39) || // 0-9
+      prev === 0x2d || // -
+      prev === 0x2e; // .
+    if (!isHostChar) return true;
+    from = idx + 1;
+  }
+  return false;
+}
+
+/**
  * Scan arbitrary text (file content, script body) for Gmail/Drive API signatures.
  * Returns the resolved module/method, or undefined if no signature is found.
  *
@@ -298,11 +328,18 @@ function detectApiSignatureInContent(
   if (lower.includes('gateway.maton.ai/google-drive')) {
     return { module: 'GoogleDrive', method: detectDriveApiMethod(lower) };
   }
-  // Direct Gmail/Drive REST API calls (not via Maton gateway)
-  if (/\bgmail\.googleapis\.com|\bwww\.googleapis\.com\/gmail/i.test(content)) {
+  // Direct Gmail/Drive REST API calls (not via Maton gateway). Boundary
+  // check rejects look-alike hosts like notgmail.googleapis.com.
+  if (
+    containsHostBoundary(lower, 'gmail.googleapis.com') ||
+    containsHostBoundary(lower, 'www.googleapis.com/gmail')
+  ) {
     return { module: 'Gmail', method: detectGmailApiMethod(lower) };
   }
-  if (/\bwww\.googleapis\.com\/drive|\bdrive\.googleapis\.com/i.test(content)) {
+  if (
+    containsHostBoundary(lower, 'www.googleapis.com/drive') ||
+    containsHostBoundary(lower, 'drive.googleapis.com')
+  ) {
     return { module: 'GoogleDrive', method: detectDriveApiMethod(lower) };
   }
   return undefined;

--- a/test/hitl/tool-interceptor.test.mjs
+++ b/test/hitl/tool-interceptor.test.mjs
@@ -179,6 +179,25 @@ test('tool-interceptor', async (t) => {
     assert.equal(interceptor.calls[0].methodName, 'delete');
   });
 
+  await t.test('does not match look-alike hosts (anchored regex)', async () => {
+    const interceptor = makeMockInterceptor();
+    const hook = createToolCallHook(interceptor);
+    await hook(
+      {
+        toolName: 'write',
+        params: {
+          path: '/tmp/script.py',
+          content: 'https://notgmail.googleapis.com/foo and https://evildrive.googleapis.com/bar',
+        },
+      },
+      { sessionKey: 's1', toolName: 'write' }
+    );
+    // Look-alike hosts must not be classified as Gmail/GoogleDrive.
+    const moduleNames = interceptor.calls.map((c) => c.moduleName);
+    assert.ok(!moduleNames.includes('Gmail'));
+    assert.ok(!moduleNames.includes('GoogleDrive'));
+  });
+
   await t.test('blocks when interceptor.evaluate throws', async () => {
     const interceptor = makeMockInterceptor({ shouldThrow: true, throwMessage: 'policy-deny' });
     const hook = createToolCallHook(interceptor);


### PR DESCRIPTION
## Summary

Resolves **3 of 25** open CodeQL alerts on `main`:

| Alert | Rule | Location |
|---|---|---|
| [#28](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/28) | `actions/unpinned-tag` | `.github/workflows/slack-notify.yml:163` |
| [#13](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/13) | `js/regex/missing-regexp-anchor` | `src/middlewares/hitl/tool-interceptor.ts:302` |
| [#14](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/14) | `js/regex/missing-regexp-anchor` | `src/middlewares/hitl/tool-interceptor.ts:305` |

### Changes

- **Pin `slackapi/slack-github-action`** from the floating `v1.27.0` tag to the immutable commit SHA `37ebaef184d7626c5f204ab8d3baff4262dd30f0`. A retag of `v1.27.0` cannot now inject new workflow code.
- **Anchor Gmail/Drive detection regexes** in `detectApiSignatureInContent` with `\b` so look-alike hosts like `notgmail.googleapis.com` or `evildrive.googleapis.com` are not classified as Gmail/Drive calls. Detection of legitimate API URLs embedded in script content is unchanged.

### Why grouped

Both fixes are tiny, contained, and have no overlap with the larger CodeQL groups still pending (ReDoS, file-system-race, etc.). Bundling them avoids two trivial PRs.

## Test plan

- [x] `node --test test/hitl/tool-interceptor.test.mjs` — 17/17 passing, including a new regression test asserting `notgmail.googleapis.com` and `evildrive.googleapis.com` do **not** classify as Gmail / GoogleDrive.
- [x] `tsc` (backend build) clean.
- [ ] CodeQL re-run on this branch confirms alerts #13, #14, #28 are resolved.
- [ ] Slack workflow still runs after the SHA pin (workflow_dispatch smoke test once merged).

## Follow-ups (not in this PR)

22 CodeQL alerts remain across 6 rule families (ReDoS, file-system-race, URL sanitization, remote-property-injection, prototype-pollution, http-to-file-access). Will be addressed in subsequent grouped PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)