### PR TITLE
fix(security): bound regex quantifiers to eliminate ReDoS (5 alerts)

### DIFF
--- a/src/middlewares/guardrail/guards/destructive-commands.ts
+++ b/src/middlewares/guardrail/guards/destructive-commands.ts
@@ -48,7 +48,9 @@ const BUILTIN_PATTERNS: DestructivePattern[] = [
   // ── File system destruction ────────────────────
   {
     name: 'rm_recursive_root',
-    pattern: /rm\s+(?:-[a-zA-Z]*[rf][a-zA-Z]*\s+)*(?:\/|~\/?\s|"\/|'\/)[\s;|&]?/i,
+    // Bounded quantifiers prevent polynomial/exponential ReDoS
+    // (CodeQL js/redos). 16 chars covers any realistic flag bundle.
+    pattern: /rm\s+(?:-[a-zA-Z]{0,16}[rf][a-zA-Z]{0,16}\s+){0,8}(?:\/|~\/?\s|"\/|'\/)[\s;|&]?/i,
     description: 'rm -rf / or home directory',
     severity: 'CRITICAL',
   },

--- a/src/middlewares/guardrail/guards/egress-control.ts
+++ b/src/middlewares/guardrail/guards/egress-control.ts
@@ -195,7 +195,10 @@ function extractHostname(urlOrHost: string): string | null {
  * Extract hostname from scp/rsync-style arguments (user@host:path).
  */
 function extractScpHostname(command: string): string | null {
-  const match = command.match(/(?:\w+@)?([a-zA-Z0-9.-]+):/);
+  // Bounded quantifiers prevent polynomial ReDoS on long inputs without
+  // a colon (CodeQL js/polynomial-redos). 64-char user, 253-char host
+  // matches RFC limits.
+  const match = command.match(/(?:\w{1,64}@)?([a-zA-Z0-9.-]{1,253}):/);
   if (match) return match[1];
   return null;
 }

--- a/src/middlewares/hitl/scoring/DestructiveClassifier.ts
+++ b/src/middlewares/hitl/scoring/DestructiveClassifier.ts
@@ -374,7 +374,9 @@ export function classifyDestructiveAction(
   }
 
   // Access control destructive operations
-  if (/revoke.*admin|delete.*user|disable.*sso|remove.*admin/.test(text)) {
+  // Bounded `.{0,80}` prevents polynomial ReDoS on long mismatching inputs
+  // (CodeQL js/polynomial-redos). 80 chars covers any realistic phrasing.
+  if (/revoke.{0,80}admin|delete.{0,80}user|disable.{0,80}sso|remove.{0,80}admin/.test(text)) {
     catastrophic = true;
     pushUnique(reasons, 'access_control_change');
   }

--- a/src/middlewares/model-routing/scoring/dimensions/structural-dimensions.ts
+++ b/src/middlewares/model-routing/scoring/dimensions/structural-dimensions.ts
@@ -85,12 +85,14 @@ export function scoreNestedListDepth(text: string): DimensionScore {
  * 0 → 0, 1 → 0.3, 2 → 0.6, 3+ → 0.9
  */
 export function scoreConditionalLogic(text: string): DimensionScore {
+  // Bounded `.{0,200}` prevents polynomial ReDoS on long inputs that contain
+  // "if " / "when " but never the closing keyword (CodeQL js/polynomial-redos).
   const patterns = [
-    /if\s.+\s*then/gi,
+    /if\s.{0,200}then/gi,
     /otherwise/gi,
     /unless/gi,
     /depending on/gi,
-    /when\s.+\s*happens/gi,
+    /when\s.{0,200}happens/gi,
     /in case/gi,
     /provided that/gi,
     /assuming/gi,
@@ -170,7 +172,9 @@ export function scoreConstraintDensity(text: string): DimensionScore {
     /cannot exceed/gi,
     /within \d+/gi,
     /between \w+ and \w+/gi,
-    /O\([^)]+\)/g,
+    // Bounded {1,100} prevents polynomial ReDoS on inputs starting with `O(`
+    // but never closing (CodeQL js/polynomial-redos).
+    /O\([^)]{1,100}\)/g,
   ];
 
   let constraintCount = 0;

--- a/test/security/redos-regressions.test.mjs
+++ b/test/security/redos-regressions.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { createTestEnvWithOpenclaw } from '../_helpers/test-env.mjs';
+
+createTestEnvWithOpenclaw('sai-redos-regressions-');
+
+const distBase = path.resolve('dist');
+const u = (p) => pathToFileURL(path.join(distBase, p)).href;
+
+// Regression tests for CodeQL-flagged ReDoS sites. Each test exercises a
+// worst-case input that, with the unbounded original regex, would trigger
+// polynomial / exponential backtracking. With bounded quantifiers in place,
+// each call must complete well under the 250ms budget.
+
+const BUDGET_MS = 250;
+
+function timed(fn) {
+  const t0 = performance.now();
+  fn();
+  return performance.now() - t0;
+}
+
+test('ReDoS: rm-recursive-root pattern terminates quickly on adversarial input', async () => {
+  const mod = await import(u('middlewares/guardrail/guards/destructive-commands.js'));
+  // 50k chars of -fr-style flag soup followed by no path — original (unbounded
+  // *) backtracks polynomially when the trailing path token never matches.
+  const adversarial = 'rm ' + '-rfafafaf '.repeat(5000) + 'xxx';
+  const ms = timed(() => mod.checkDestructiveCommand(adversarial));
+  assert.ok(ms < BUDGET_MS, `took ${ms.toFixed(1)}ms (budget ${BUDGET_MS}ms)`);
+});
+
+test('ReDoS: egress extractScpHostname terminates quickly on no-colon input', async () => {
+  const mod = await import(u('middlewares/guardrail/guards/egress-control.js'));
+  // Long alnum string with no `:` — original /(?:\w+@)?([a-zA-Z0-9.-]+):/
+  // would try every start position with greedy backtracking.
+  const adversarial = 'a'.repeat(100000);
+  const ms = timed(() => mod.checkEgressControl(`scp ${adversarial} dest`));
+  assert.ok(ms < BUDGET_MS, `took ${ms.toFixed(1)}ms (budget ${BUDGET_MS}ms)`);
+});
+
+test('ReDoS: DestructiveClassifier access-control patterns terminate quickly', async () => {
+  const mod = await import(u('middlewares/hitl/scoring/DestructiveClassifier.js'));
+  // Input that hits each `<verb>.*<target>` alternative without ever reaching
+  // the closing keyword — original `.*` would polynomial-backtrack.
+  const adversarial = 'revoke ' + 'x'.repeat(100000);
+  const ms = timed(() => mod.classifyDestructiveAction('unknown', { text: adversarial }));
+  assert.ok(ms < BUDGET_MS, `took ${ms.toFixed(1)}ms (budget ${BUDGET_MS}ms)`);
+});
+
+test('ReDoS: scoreConditionalLogic if/then + when/happens patterns terminate quickly', async () => {
+  const mod = await import(
+    u('middlewares/model-routing/scoring/dimensions/structural-dimensions.js')
+  );
+  // Long input starting with "if " / "when " but never closing — original
+  // `.+\s*` would polynomial-backtrack.
+  const adversarial = 'if ' + 'x'.repeat(100000);
+  const ms = timed(() => mod.scoreConditionalLogic(adversarial));
+  assert.ok(ms < BUDGET_MS, `took ${ms.toFixed(1)}ms (budget ${BUDGET_MS}ms)`);
+});
+
+test('ReDoS: scoreConstraintDensity O(...) pattern terminates quickly', async () => {
+  const mod = await import(
+    u('middlewares/model-routing/scoring/dimensions/structural-dimensions.js')
+  );
+  // Long input with `O(` and no closing `)` — original `[^)]+` would
+  // polynomial-backtrack.
+  const adversarial = 'O(' + 'x'.repeat(100000);
+  const ms = timed(() => mod.scoreConstraintDensity(adversarial));
+  assert.ok(ms < BUDGET_MS, `took ${ms.toFixed(1)}ms (budget ${BUDGET_MS}ms)`);
+});


### PR DESCRIPTION
## Summary

Resolves **5 of 22** open CodeQL alerts on `main` — all in the ReDoS family.

| Alert | Rule | Location |
|---|---|---|
| [#10](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/10) | `js/redos` (high) | `src/middlewares/guardrail/guards/destructive-commands.ts:51` |
| [#6](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/6) | `js/polynomial-redos` (high) | `src/middlewares/guardrail/guards/egress-control.ts:198` |
| [#7](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/7) | `js/polynomial-redos` (high) | `src/middlewares/hitl/scoring/DestructiveClassifier.ts:377` |
| [#8](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/8) | `js/polynomial-redos` (high) | `src/middlewares/model-routing/scoring/dimensions/structural-dimensions.ts:103` |
| [#9](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/9) | `js/polynomial-redos` (high) | `src/middlewares/model-routing/scoring/dimensions/structural-dimensions.ts:178` |

## Fix pattern

All five sites use the same surgical change: replace unbounded quantifiers (`*`, `+`, `.*`) with bounded forms (`{0,N}`, `{1,N}`, `.{0,N}`). The caps are generous enough to preserve behavior on realistic inputs but eliminate polynomial / exponential backtracking on adversarial inputs.

| Site | Before | After |
|---|---|---|
| `destructive-commands.ts:51` | `(?:-[a-zA-Z]*[rf][a-zA-Z]*\s+)*` | `(?:-[a-zA-Z]{0,16}[rf][a-zA-Z]{0,16}\s+){0,8}` |
| `egress-control.ts:198` | `(?:\w+@)?([a-zA-Z0-9.-]+):` | `(?:\w{1,64}@)?([a-zA-Z0-9.-]{1,253}):` (RFC limits) |
| `DestructiveClassifier.ts:377` | `revoke.*admin\|delete.*user\|...` | `revoke.{0,80}admin\|delete.{0,80}user\|...` |
| `structural-dimensions.ts` (if/when) | `if\s.+\s*then`, `when\s.+\s*happens` | `if\s.{0,200}then`, `when\s.{0,200}happens` |
| `structural-dimensions.ts` (O-notation) | `O\([^)]+\)` | `O\([^)]{1,100}\)` |

## Test plan

- [x] **New regression test:** `test/security/redos-regressions.test.mjs` — five tests, each runs a 50k–100k-char adversarial input against the fixed regex and asserts completion under **250ms**. All pass; the slowest (`extractScpHostname` on 100k `a`s with no `:`) completes in ~105ms.
- [x] `npm test` — **415/415 passing** (5 new + 410 existing).
- [x] `npm run build:backend` — clean.
- [ ] CodeQL re-run on this branch confirms alerts #6, #7, #8, #9, #10 are resolved.

## Behavior preservation

The bounded quantifiers were chosen to exceed any realistic input shape:
- `rm` flag bundles: 16 chars × 8 groups = 128 chars (real commands ≤ 20)
- SCP user/host: 64/253 chars (RFC 5321/1035)
- Access-control phrases: 80 chars between verb and target (real phrasing ≤ 30)
- Conditional clauses: 200 chars between `if`/`when` and closer (real ≤ 80)
- O(...) notation: 100 chars inside parens (real ≤ 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)