### PR TITLE
fix(security): reject prototype-polluting path segments in setNestedValue

### DIFF
--- a/src/shared/server/openclaw-sync.ts
+++ b/src/shared/server/openclaw-sync.ts
@@ -170,6 +170,13 @@ export async function clearPendingWrites(): Promise<void> {
 
 function setNestedValue(obj: Record<string, unknown>, dotPath: string, value: unknown): void {
   const keys = dotPath.split('.');
+  // Reject any path segment that could pollute Object.prototype
+  // (CodeQL js/prototype-pollution-utility).
+  for (const k of keys) {
+    if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+      throw new Error(`Refusing to set property at unsafe path segment: ${k}`);
+    }
+  }
   let current: Record<string, unknown> = obj;
 
   for (let i = 0; i < keys.length - 1; i++) {

--- a/src/shared/storage/ConfigStore.ts
+++ b/src/shared/storage/ConfigStore.ts
@@ -168,6 +168,13 @@ export class ConfigStore {
 
   private static setNestedValue(obj: any, pathStr: string, value: any) {
     const keys = pathStr.split('.');
+    // Reject any path segment that could pollute Object.prototype
+    // (CodeQL js/prototype-pollution-utility).
+    for (const k of keys) {
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
+        throw new Error(`Refusing to set property at unsafe path segment: ${k}`);
+      }
+    }
     let current = obj;
     for (let i = 0; i < keys.length - 1; i++) {
       if (!current[keys[i]] || typeof current[keys[i]] !== 'object') {

--- a/test/security/prototype-pollution.test.mjs
+++ b/test/security/prototype-pollution.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { createTestEnvWithOpenclaw } from '../_helpers/test-env.mjs';
+
+createTestEnvWithOpenclaw('sai-prototype-pollution-');
+
+const distBase = path.resolve('dist');
+const u = (p) => pathToFileURL(path.join(distBase, p)).href;
+
+// Regression tests for CodeQL js/prototype-pollution-utility (#4, #5).
+// Both setNestedValue helpers must refuse to write through path segments
+// that could pollute Object.prototype.
+
+test('ConfigStore.updateSync refuses __proto__ in dotted path', async () => {
+  const { ConfigStore } = await import(u('shared/storage/ConfigStore.js'));
+
+  // Snapshot prototype to detect any leak.
+  // eslint-disable-next-line no-proto
+  const protoBefore = {}.__proto__;
+
+  assert.throws(() => ConfigStore.updateSync('__proto__.polluted', 'oops'), /unsafe path segment/);
+  assert.throws(
+    () => ConfigStore.updateSync('a.b.__proto__.polluted', 'oops'),
+    /unsafe path segment/
+  );
+  assert.throws(() => ConfigStore.updateSync('constructor.x', 'oops'), /unsafe path segment/);
+  assert.throws(() => ConfigStore.updateSync('prototype.x', 'oops'), /unsafe path segment/);
+
+  // Object.prototype must be unchanged.
+  // eslint-disable-next-line no-proto
+  assert.equal({}.__proto__, protoBefore);
+  assert.equal({}.polluted, undefined);
+});


### PR DESCRIPTION
## Summary

Resolves **2 of 17** open CodeQL alerts on `main`.

| Alert | Rule | Location |
|---|---|---|
| [#5](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/5) | `js/prototype-pollution-utility` (medium) | `src/shared/storage/ConfigStore.ts:178` |
| [#4](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/4) | `js/prototype-pollution-utility` (medium) | `src/shared/server/openclaw-sync.ts:183` |

Both sites have a `setNestedValue(obj, dotPath, value)` helper that walks `dotPath` and writes the value at the leaf. With an attacker-controlled path of `__proto__.polluted`, `current["__proto__"]` resolves to `Object.prototype` and the assignment pollutes every object in the process.

## Fix

Validate every path segment up front and throw on `__proto__`, `constructor`, or `prototype` — same pattern in both helpers:

```ts
for (const k of keys) {
  if (k === '__proto__' || k === 'constructor' || k === 'prototype') {
    throw new Error(`Refusing to set property at unsafe path segment: ${k}`);
  }
}
```

Throw rather than silent-drop so misuse is loud, not stealthy.

## Test plan

- [x] **New regression test:** `test/security/prototype-pollution.test.mjs` asserts:
  - all three dangerous segments are rejected
  - rejection happens at any depth (`a.b.__proto__.x`)
  - `Object.prototype` is unchanged after the throws
- [x] `npm test` — **416/416 passing**.
- [x] `npm run build:backend` — clean.
- [ ] CodeQL re-run on this branch confirms alerts #4, #5 are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)