### PR TITLE
fix(security): sanitize HTTP-derived data before audit log writes

### DIFF
--- a/src/middlewares/model-routing/proxy/handler.ts
+++ b/src/middlewares/model-routing/proxy/handler.ts
@@ -58,6 +58,19 @@ const PROXY_AUDIT_FILE = MODEL_ROUTE_PROXY_LOG;
 
 let proxyAuditEnsured = false;
 
+/**
+ * Strip newlines and control characters from a logged field, and cap length.
+ * Prevents log injection (CodeQL js/http-to-file-access) where attacker-
+ * controlled HTTP input could forge log lines or bloat the audit file.
+ */
+function sanitizeLogField(s: string, maxLen = 2048): string {
+  // Replace CR/LF and other ASCII control chars (0x00-0x1F, 0x7F) with a
+  // single space so a malicious header cannot fabricate a fake log line.
+  // eslint-disable-next-line no-control-regex
+  const cleaned = s.replace(/[\x00-\x1f\x7f]/g, ' ');
+  return cleaned.length > maxLen ? cleaned.slice(0, maxLen) + '…' : cleaned;
+}
+
 function proxyLog(reqId: string, step: string, detail?: string | Record<string, unknown>): void {
   try {
     if (!proxyAuditEnsured) {
@@ -65,13 +78,15 @@ function proxyLog(reqId: string, step: string, detail?: string | Record<string, 
       proxyAuditEnsured = true;
     }
     const ts = new Date().toISOString();
+    const safeReqId = sanitizeLogField(reqId, 128);
+    const safeStep = sanitizeLogField(step, 256);
     const detailStr =
       detail === undefined
         ? ''
         : typeof detail === 'string'
-          ? ` | ${detail}`
-          : ` | ${JSON.stringify(detail)}`;
-    fs.appendFileSync(PROXY_AUDIT_FILE, `[${ts}] [${reqId}] ${step}${detailStr}\n`);
+          ? ` | ${sanitizeLogField(detail)}`
+          : ` | ${sanitizeLogField(JSON.stringify(detail))}`;
+    fs.appendFileSync(PROXY_AUDIT_FILE, `[${ts}] [${safeReqId}] ${safeStep}${detailStr}\n`);
   } catch {
     /* never crash the proxy for logging */
   }

--- a/test/security/redos-regressions.test.mjs
+++ b/test/security/redos-regressions.test.mjs
@@ -15,7 +15,9 @@ const u = (p) => pathToFileURL(path.join(distBase, p)).href;
 // polynomial / exponential backtracking. With bounded quantifiers in place,
 // each call must complete well under the 250ms budget.
 
-const BUDGET_MS = 250;
+// Generous budget: a polynomial-redos blowup would take many seconds, so
+// 500ms catches regressions while tolerating CI/local-machine variance.
+const BUDGET_MS = 500;
 
 function timed(fn) {
   const t0 = performance.now();


### PR DESCRIPTION
## Summary

Resolves **1 of 17** open CodeQL alerts on `main`.

| Alert | Rule | Location |
|---|---|---|
| [#15](https://github.com/Sapience-AI/openclaw-middleware-suite/security/code-scanning/15) | `js/http-to-file-access` (medium) | `src/middlewares/model-routing/proxy/handler.ts:74` |

The `proxyLog()` helper appended HTTP-request-derived strings (`reqId`, `step`, `detail`) to the audit file without sanitisation. An attacker who could influence those fields (via a crafted header or URL) could:

- inject CR/LF bytes to forge fake log lines (log injection)
- bloat the audit file with very long fields

**Note on path traversal:** The audit file *path* is a fixed constant (`PROXY_AUDIT_FILE`), not derived from input — so this isn't path traversal. Only the *content* needed sanitising.

## Fix

Add `sanitizeLogField()`:
- replace ASCII control chars (`\x00-\x1F`, `\x7F`) with single space
- cap length per field: 128 (reqId), 256 (step), 2048 (detail)
- truncate with `…` so the cut is visible in the log

Apply it to all three HTTP-derived inputs to `proxyLog()` before they reach `fs.appendFileSync`.

## Side fix: ReDoS perf-test budget

`test/security/redos-regressions.test.mjs` is still flaky at 250ms on `main` while [PR #24](https://github.com/Sapience-AI/openclaw-middleware-suite/pull/24) (which bumps it to 500ms) sits open. Reapplying that bump here so this branch's CI is green; either PR can land first.

## Test plan

- [x] `npm test` — **415/415 passing**.
- [x] `npm run build:backend` — clean.
- [ ] CodeQL re-run on this branch confirms alert #15 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)