### PR TITLE
docs(notice): record Apache 2.0 §4(d) verification for upstream NOTICE files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,6 +9,22 @@ This product includes software derived from third-party open-source projects.
 The applicable copyright notices, license terms, and required attributions are
 listed below.
 
+Apache License, Version 2.0, Section 4(d) compliance note: where an upstream
+Apache-2.0 project ships its own NOTICE file, Section 4(d) requires the
+attribution-notice portion of that file to be reproduced verbatim in this
+NOTICE. As of the date below, the upstream Apache-2.0 projects referenced in
+this file (Reins, OpenClaw Shield, OpenGuardrails) do not distribute a NOTICE
+file — only a LICENSE file — so no additional verbatim attribution text is
+required. This was verified by inspecting the root of each upstream repository:
+
+    - https://github.com/pegasi-ai/reins             (no NOTICE; LICENSE only)
+    - https://github.com/knostic/openclaw-shield     (no NOTICE; LICENSE only)
+    - https://github.com/openguardrails/openguardrails (no NOTICE; LICENSE only)
+
+Verified: 2026-05-04. If any upstream project later adds a NOTICE file, the
+relevant attribution portion must be reproduced verbatim under the matching
+section below.
+
 ================================================================================
 1. Reins (Human-in-the-Loop Middleware)
 ================================================================================


### PR DESCRIPTION
## Summary
Apache License 2.0 §4(d) requires that if an upstream Apache-2.0 project ships a NOTICE file, the attribution-notice portion be reproduced verbatim in our NOTICE. This was previously unverified for the three Apache-2.0 upstreams referenced in [NOTICE](NOTICE) — Reins, OpenClaw Shield, OpenGuardrails.

**Verification performed (2026-05-04):**
- [pegasi-ai/reins](https://github.com/pegasi-ai/reins) — no NOTICE file; only LICENSE.
- [knostic/openclaw-shield](https://github.com/knostic/openclaw-shield) — no NOTICE file; only LICENSE.
- [openguardrails/openguardrails](https://github.com/openguardrails/openguardrails) — no NOTICE file; only LICENSE.

Result: no verbatim attribution text needs to be added — §4(d) is satisfied as-is. The NOTICE is updated to record the verification (with the date and the upstream URLs) so future compliance reviews can see this was checked, and so reviewers know to paste in upstream NOTICE content if any upstream later adds one.

## Test plan
- [x] Verified absence of `NOTICE` / `NOTICE.txt` / `NOTICE.md` at the root of each upstream repo via the GitHub API.
- [x] No code changes — documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)