### PR TITLE
docs(notice): pin OpenGuardrails LICENSE to commit, quote conditions verbatim

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -244,25 +244,124 @@ OpenGuardrails project.
 
   Project:   OpenGuardrails
   Source:    https://github.com/openguardrails/openguardrails
-  License:   Apache License, Version 2.0 (modified — with additional
-             conditions covering multi-tenant SaaS use and frontend brand
-             attribution; see the upstream LICENSE for details)
-  License text: https://www.apache.org/licenses/LICENSE-2.0
+             (pinned snapshot: commit b079ea095c, 2026-02-15)
+  License:   Modified Apache License, Version 2.0 — a non-canonical license
+             that incorporates the Apache 2.0 grant and adds two upstream-
+             specific conditions (multi-tenant SaaS prohibition and frontend
+             brand-attribution requirement), plus a contributor agreement.
+             This is NOT the standard Apache 2.0; the additional conditions
+             are reproduced verbatim below and the upstream LICENSE text is
+             pinned to a specific commit so the terms cannot silently shift.
+  Upstream LICENSE (pinned): https://github.com/openguardrails/openguardrails/blob/b079ea095c/LICENSE
+  Apache 2.0 base text (referenced by the upstream license):
+                              https://www.apache.org/licenses/LICENSE-2.0
 
   Copyright (c) OpenGuardrails contributors. All rights reserved.
 
-  Licensed under the Apache License, Version 2.0 (the "License") with the
-  additional conditions stated in the upstream LICENSE file. You may not
-  use the affected files except in compliance with the License. Unless
-  required by applicable law or agreed to in writing, software distributed
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-  CONDITIONS OF ANY KIND, either express or implied.
+  Licensed under the Modified Apache License, Version 2.0 described above.
+  You may not use the affected files except in compliance with that license.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the license is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
-  Note on the additional conditions: the OpenClaw Middleware Suite uses
-  OpenGuardrails purely as a backend / SDK-style component. It does not
-  embed, redistribute, or expose the OpenGuardrails frontend interface,
-  and it does not operate a multi-tenant SaaS environment based on the
-  OpenGuardrails source code.
+  ----------------------------------------------------------------------------
+  Additional conditions (reproduced verbatim from the upstream LICENSE at
+  commit b079ea095c):
+  ----------------------------------------------------------------------------
+
+      # Open Source License
+
+      OpenGuardrails is licensed under a modified version of the Apache
+      License 2.0, with the following additional conditions:
+
+      1. OpenGuardrails may be utilized commercially, including as a backend
+      service for other applications or as an application development
+      platform for enterprises. Should the conditions below be met, a
+      commercial license must be obtained from the producer:
+
+      a. Multi-tenant service: Unless explicitly authorized by OpenGuardrails
+      in writing, you may not use the OpenGuardrails source code to operate a
+      multi-tenant SaaS environment.
+          - Tenant Definition:
+          Within the context of OpenGuardrails, a tenant refers to a
+          logically isolated instance used by an independent user,
+          organization, or client.
+          Multi-tenancy includes — but is not limited to — providing
+          separate user environments, dashboards, or API spaces for multiple
+          customers in one hosted system.
+          - Examples:
+          Using OpenGuardrails within your own company or organization →
+          Allowed.
+          Delivering a single customized instance to one enterprise customer
+          → Allowed.
+          Operating a hosted SaaS platform where multiple users register and
+          use isolated environments → Requires commercial license.
+
+      b. Brand identity and attribution:
+          When using OpenGuardrails' frontend interface, you may not remove,
+          obscure, or modify the OpenGuardrails LOGO, product name, or
+          copyright information displayed in the product console, web
+          interface, or related applications.
+          This restriction does not apply to deployments that use
+          OpenGuardrails purely as a backend or SDK component without its
+          frontend interface.
+          - Frontend Definition:
+          The frontend refers to all source code and assets within the
+          frontend/ directory of the OpenGuardrails repository, or the
+          corresponding "frontend" image when running via Docker.
+
+      2. As a contributor, you should agree that:
+
+      a. The producer can adjust the open-source agreement to be more strict
+      or relaxed as deemed necessary.
+      b. Your contributed code may be used for commercial purposes,
+      including but not limited to its cloud business operations.
+
+      Apart from the specific conditions mentioned above, all other rights
+      and restrictions follow the Apache License 2.0. Detailed information
+      about the Apache License 2.0 can be found at
+      http://www.apache.org/licenses/LICENSE-2.0.
+
+      The interactive design of this product is protected by appearance
+      patent.
+
+  ----------------------------------------------------------------------------
+  Compliance posture for this project:
+  ----------------------------------------------------------------------------
+
+  - Multi-tenant SaaS (condition 1.a): the OpenClaw Middleware Suite is a
+    library that runs locally inside the user's own agent process. It is not
+    operated as a hosted multi-tenant SaaS by this project, and the
+    OpenGuardrails-derived rules below are exercised inside the end user's
+    own deployment. Downstream redistributors who use the OpenGuardrails-
+    derived rules to power a multi-tenant SaaS must obtain a commercial
+    license directly from OpenGuardrails — that obligation is not waivable
+    by us.
+  - Brand identity (condition 1.b): the restriction applies only to the
+    OpenGuardrails frontend (the `frontend/` directory / Docker image of the
+    upstream repo). This project does not embed, redistribute, or expose
+    that frontend; only backend rule definitions and classification
+    patterns are derived. The condition therefore does not attach to the
+    derivation in this repository.
+
+  ----------------------------------------------------------------------------
+  Important notice on upstream relicensing:
+  ----------------------------------------------------------------------------
+
+  The OpenGuardrails project relicensed to GNU AGPL-3.0 on 2026-04-17
+  (commit f2db52dabb, "Update version to 7.0.0, new oss for agent
+  security") and was subsequently renamed to "thomas" (now hosted at
+  https://github.com/trustunknown/thomas). The pinned snapshot referenced
+  above (commit b079ea095c, 2026-02-15) predates that relicense, so the
+  derivation reflected in this NOTICE is governed by the modified Apache
+  2.0 terms reproduced verbatim above — not by AGPL-3.0.
+
+  Maintainers MUST NOT pull additional code, rules, taxonomy entries, or
+  patterns from any commit of the upstream repository at or after
+  f2db52dabb without first re-evaluating license compatibility with this
+  project, as AGPL-3.0 imposes copyleft and network-server source-
+  disclosure obligations that are incompatible with the Apache-2.0 license
+  under which this product as a whole is distributed.
 
   The following files in this repository contain detection rules and
   classification patterns derived from the OpenGuardrails risk taxonomy

--- a/NOTICE
+++ b/NOTICE
@@ -244,7 +244,7 @@ OpenGuardrails project.
 
   Project:   OpenGuardrails
   Source:    https://github.com/openguardrails/openguardrails
-             (pinned snapshot: commit b079ea095c, 2026-02-15)
+             (pinned snapshot dated 2026-02-15; see pinned LICENSE URL below)
   License:   Modified Apache License, Version 2.0 — a non-canonical license
              that incorporates the Apache 2.0 grant and adds two upstream-
              specific conditions (multi-tenant SaaS prohibition and frontend
@@ -266,7 +266,7 @@ OpenGuardrails project.
 
   ----------------------------------------------------------------------------
   Additional conditions (reproduced verbatim from the upstream LICENSE at
-  commit b079ea095c):
+  the pinned snapshot referenced above):
   ----------------------------------------------------------------------------
 
       # Open Source License
@@ -348,20 +348,20 @@ OpenGuardrails project.
   Important notice on upstream relicensing:
   ----------------------------------------------------------------------------
 
-  The OpenGuardrails project relicensed to GNU AGPL-3.0 on 2026-04-17
-  (commit f2db52dabb, "Update version to 7.0.0, new oss for agent
-  security") and was subsequently renamed to "thomas" (now hosted at
+  The OpenGuardrails project relicensed to GNU AGPL-3.0 on 2026-04-17 and
+  was subsequently renamed to "thomas" (now hosted at
   https://github.com/trustunknown/thomas). The pinned snapshot referenced
-  above (commit b079ea095c, 2026-02-15) predates that relicense, so the
-  derivation reflected in this NOTICE is governed by the modified Apache
-  2.0 terms reproduced verbatim above — not by AGPL-3.0.
+  above (dated 2026-02-15) predates that relicense, so the derivation
+  reflected in this NOTICE is governed by the modified Apache 2.0 terms
+  reproduced verbatim above — not by AGPL-3.0.
 
   Maintainers MUST NOT pull additional code, rules, taxonomy entries, or
-  patterns from any commit of the upstream repository at or after
-  f2db52dabb without first re-evaluating license compatibility with this
-  project, as AGPL-3.0 imposes copyleft and network-server source-
-  disclosure obligations that are incompatible with the Apache-2.0 license
-  under which this product as a whole is distributed.
+  patterns from any version of the upstream repository dated on or after
+  the AGPL-3.0 relicense (2026-04-17) without first re-evaluating license
+  compatibility with this project, as AGPL-3.0 imposes copyleft and
+  network-server source-disclosure obligations that are incompatible with
+  the Apache-2.0 license under which this product as a whole is
+  distributed.
 
   The following files in this repository contain detection rules and
   classification patterns derived from the OpenGuardrails risk taxonomy


### PR DESCRIPTION
## Summary

Three issues with the OpenGuardrails section of [NOTICE](NOTICE) — all flagged in a license-compliance audit:

1. The `License-text` URL pointed at the **canonical Apache 2.0 page**, which describes the *unmodified* license. The upstream OpenGuardrails LICENSE is a non-canonical "modified Apache 2.0" with extra conditions — the canonical URL was misleading.
2. The additional conditions were referenced but **not quoted**, forcing downstream readers to round-trip to GitHub just to see the terms.
3. The upstream Source URL was **unpinned**, so the terms we accepted could silently shift.

## Critical finding during the audit

While verifying point (3), I confirmed the conditions in fact **did shift**:

| Date | Commit | License |
|---|---|---|
| 2025-10-22 | `82ac52b9` | plain Apache 2.0 |
| 2025-10-24 | `5ed93ce3` | modified Apache 2.0 (what our NOTICE describes) |
| 2026-02-15 | `b079ea09` | modified Apache 2.0 *(last commit under it)* |
| **2026-04-17** | **`f2db52da`** | **🔁 relicensed to GNU AGPL-3.0** |
| 2026-04-30 | `dd936fa9` | AGPL-3.0; repo renamed to [`trustunknown/thomas`](https://github.com/trustunknown/thomas) |

Our derivation predates the AGPL switch, so the modified-Apache-2.0 grant we accepted remains valid for the snapshot we took. Pinning to `b079ea09` locks our position in writing.

## Fixes in this PR (NOTICE only — no code changes)

- **Pinned** the upstream LICENSE URL to `b079ea095c`.
- **Quoted** the additional conditions **verbatim** from that commit (multi-tenant SaaS prohibition, frontend brand-attribution requirement, contributor agreement).
- **Replaced** the misleading canonical Apache 2.0 URL with the pinned upstream URL, and relabeled the license clearly as "Modified Apache License, Version 2.0 — a non-canonical license."
- **Added a compliance-posture note** explaining how each condition applies (or does not apply) to this project — e.g. brand-attribution does not attach because we don't redistribute the upstream `frontend/`.
- **Added a maintainer warning** that any future code/rule pulled from upstream at or after `f2db52da` carries AGPL-3.0 obligations incompatible with this project's Apache-2.0 distribution, and must not be merged without re-evaluating license compatibility.

## Test plan
- [x] Verified upstream LICENSE history via `gh api repos/openguardrails/openguardrails/commits?path=LICENSE`.
- [x] Confirmed `b079ea095c` LICENSE matches the verbatim block reproduced in NOTICE.
- [x] Confirmed `f2db52dabb` LICENSE is AGPL-3.0 (FSF text).
- [x] No code touched — `git diff --stat` shows only `NOTICE` modified.