### PR TITLE
docs(notice): mirror OpenGuardrails upstream copyright string verbatim

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -232,7 +232,7 @@ OpenGuardrails project.
              upstream-specific conditions reproduced verbatim below)
   Upstream LICENSE (pinned): https://github.com/openguardrails/openguardrails/blob/b079ea095c/LICENSE
 
-  Copyright (c) OpenGuardrails contributors. All rights reserved.
+  Copyright (c) 2026 OpenGuardrails.com
 
   Licensed under the Modified Apache License, Version 2.0 described above.
   You may not use the affected files except in compliance with that license.


### PR DESCRIPTION
## Summary

Verifying Finding 2 from the legal review surfaced one mismatch: NOTICE Section 5 was synthesizing the OpenGuardrails copyright (`Copyright (c) OpenGuardrails contributors. All rights reserved.`) instead of mirroring what the upstream LICENSE actually carries.

The upstream LICENSE at the pinned snapshot (`b079ea095c`) contains:

```
© 2026 OpenGuardrails.com
```

Bringing our NOTICE in line — one-line change.

```diff
- Copyright (c) OpenGuardrails contributors. All rights reserved.
+ Copyright (c) 2026 OpenGuardrails.com
```

This matches how we already handle Manifest (`Copyright (c) 2026 MNFST, Inc`) and ClawRouter (`Copyright (c) 2026 BlockRunAI`) — verbatim mirror of the upstream copyright string.

## Test plan
- [x] Verified upstream string via `gh api repos/openguardrails/openguardrails/contents/LICENSE?ref=b079ea095c`.
- [x] No code changes — `git diff --stat` shows only `NOTICE` modified, 1/1.